### PR TITLE
Update the Notepad convenience initializer

### DIFF
--- a/Notepad/Notepad.swift
+++ b/Notepad/Notepad.swift
@@ -18,7 +18,7 @@ public class Notepad: UITextView {
     /// - parameter themeFile: The name of the theme file to use.
     ///
     /// - returns: A new Notepad.
-    convenience init(_ frame: CGRect, themeFile: String) {
+    convenience public init(_ frame: CGRect, themeFile: String) {
         self.init(frame: frame, textContainer: nil)
         self.storage.theme = Theme(themeFile)
         self.backgroundColor = self.storage.theme.backgroundColor

--- a/Notepad/Notepad.swift
+++ b/Notepad/Notepad.swift
@@ -18,7 +18,7 @@ public class Notepad: UITextView {
     /// - parameter themeFile: The name of the theme file to use.
     ///
     /// - returns: A new Notepad.
-    convenience public init(_ frame: CGRect, themeFile: String) {
+    convenience public init(frame: CGRect, themeFile: String) {
         self.init(frame: frame, textContainer: nil)
         self.storage.theme = Theme(themeFile)
         self.backgroundColor = self.storage.theme.backgroundColor

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ## Usage
 
 ```swift
-let notepad = Notepad(view.bounds, themeFile: "one-dark")
+let notepad = Notepad(frame: view.bounds, themeFile: "one-dark")
 view.addSubview(notepad)
 ```
 Notepad is just like any other UITextView, but you need to use the convenience initializer in order to use the themes. To create a new theme, copy one of the existing themes and edit the JSON.


### PR DESCRIPTION
I made the Notepad convenience init public because if it isn't explicitly stated that it's public, Swift assumes it to be internal (and, therefore, inaccessible to anyone using Notepad via Cocoapods, etc.).

I also changed the Notepad convenience initializer so as not to hide the frame parameter name. This is more in line with the explicit function naming conventions in Swift 3. The README has been updated to reflect this change.