### PR TITLE
Update Example project and fix theme loading

### DIFF
--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -14,7 +14,7 @@ class ViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        let editor = Notepad(self.view.bounds, themeFile: "one-dark")
+        let editor = Notepad(frame: self.view.bounds, themeFile: "one-dark")
 
         let testFile = Bundle.main.path(forResource: "tests", ofType: "md")
         do {

--- a/Notepad/Theme.swift
+++ b/Notepad/Theme.swift
@@ -26,13 +26,28 @@ public struct Theme {
     ///
     /// - returns: The Theme.
     init(_ name: String) {
-        if let path = Bundle(for: object_getClass(self)).path(forResource: "Notepad.framework/themes/\(name)", ofType: "json") {
-            if let data = convertFile(path) {
-                configure(data)
-            }
+        let bundle = Bundle(for: object_getClass(self))
+        
+        let path: String
+        
+        if let path1 = bundle.path(forResource: "Notepad.framework/themes/\(name)", ofType: "json") {
+            
+            path = path1
+        }
+        else if let path2 = bundle.path(forResource: "Notepad.framework/\(name)", ofType: "json") {
+            
+            path = path2
         }
         else {
+            
             print("[Notepad] Unable to load your theme file.")
+            
+            return
+        }
+        
+        if let data = convertFile(path) {
+            
+            configure(data)
         }
     }
 


### PR DESCRIPTION
The theme file path 'Notepad.framework/themes/\(name)' only works when dragging the Notepad files directly into your project (e.g. the Example project). When using Cocoapods to install Notepad, the theme json files aren't located in a folder named 'themes', presumably because 'themes' is a folder reference, not a group. Therefore, when using Cocoapods, the correct file path is actually just 'Notepad.framework/\(name)'. This commit fixes that issue by checking both file paths before printing '[Notepad] Unable to load your theme file', insuring that the theme file is loaded correctly both when installed locally and when using Cocoapods. A better approach would probably be to just make the themes folder a group instead of a reference, therefore making the filepath the same no matter what, but this will work for now, too.

I also updated the Example project to reflect the changes added in my last pull request.