### PR TITLE
Allow specifying the theme path directly

### DIFF
--- a/Notepad/Notepad.swift
+++ b/Notepad/Notepad.swift
@@ -25,6 +25,14 @@ public class Notepad: UITextView {
         self.tintColor = self.storage.theme.tintColor
         self.autoresizingMask = [.flexibleWidth, .flexibleHeight]
     }
+    
+    convenience public init(frame: CGRect, theme: Theme) {
+        self.init(frame: frame, textContainer: nil)
+        self.storage.theme = theme
+        self.backgroundColor = self.storage.theme.backgroundColor
+        self.tintColor = self.storage.theme.tintColor
+        self.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+    }
 
     override init(frame: CGRect, textContainer: NSTextContainer?) {
         let layoutManager = NSLayoutManager()

--- a/Notepad/Theme.swift
+++ b/Notepad/Theme.swift
@@ -46,7 +46,12 @@ public struct Theme {
         }
         
         if let data = convertFile(path) {
-            
+            configure(data)
+        }
+    }
+    
+    init(themePath: String) {
+        if let data = convertFile(themePath) {
             configure(data)
         }
     }

--- a/Notepad/Theme.swift
+++ b/Notepad/Theme.swift
@@ -25,7 +25,7 @@ public struct Theme {
     /// - parameter name: The name of the JSON theme file.
     ///
     /// - returns: The Theme.
-    init(_ name: String) {
+    public init(_ name: String) {
         let bundle = Bundle(for: object_getClass(self))
         
         let path: String
@@ -50,7 +50,7 @@ public struct Theme {
         }
     }
     
-    init(themePath: String) {
+    public init(themePath: String) {
         if let data = convertFile(themePath) {
             configure(data)
         }


### PR DESCRIPTION
This is useful for installation through Cocoapods -- I'd like to use a theme file located in my own project's repository.