### PR TITLE
Fixed an incorrent API usage (which could cause a crash)

### DIFF
--- a/Notepad/Storage.swift
+++ b/Notepad/Storage.swift
@@ -68,7 +68,7 @@ public class Storage: NSTextStorage {
     ///
     /// - returns: The attributes on a String within a certain range.
     override public func attributes(at location: Int, longestEffectiveRange range: NSRangePointer?, in rangeLimit: NSRange) -> [NSAttributedStringKey : Any] {
-        return backingStore.attributes(at: location, effectiveRange: range)
+        return backingStore.attributes(at: location, longestEffectiveRange: range, in: rangeLimit)
     }
 
     /// Replaces edited characters within a certain range with a new string.


### PR DESCRIPTION
This PR fixes a small API usage issue (which was probably just a typo).
The issue causes a crash if you try to paste markdown into the notepad text view (I tested on samples from https://jaspervdj.be/lorem-markdownum/).
Also it fixes the warning reported in #40.