### PR TITLE
Changed NSAttributedStringKey cases to NSAttributedString.Key

### DIFF
--- a/Notepad/Storage.swift
+++ b/Notepad/Storage.swift
@@ -67,7 +67,7 @@ public class Storage: NSTextStorage {
     /// - parameter range:    The range to find attributes for.
     ///
     /// - returns: The attributes on a String within a certain range.
-    override public func attributes(at location: Int, longestEffectiveRange range: NSRangePointer?, in rangeLimit: NSRange) -> [NSAttributedStringKey : Any] {
+    override public func attributes(at location: Int, longestEffectiveRange range: NSRangePointer?, in rangeLimit: NSRange) -> [NSAttributedString.Key : Any] {
         return backingStore.attributes(at: location, longestEffectiveRange: range, in: rangeLimit)
     }
 
@@ -88,7 +88,7 @@ public class Storage: NSTextStorage {
     ///
     /// - parameter attrs: The attributes to add to the string for the range.
     /// - parameter range: The range in which to add attributes.
-    public override func setAttributes(_ attrs: [NSAttributedStringKey : Any]?, range: NSRange) {
+    public override func setAttributes(_ attrs: [NSAttributedString.Key : Any]?, range: NSRange) {
         self.beginEditing()
         backingStore.setAttributes(attrs, range: range)
         self.edited(.editedAttributes, range: range, changeInLength: 0)
@@ -99,7 +99,7 @@ public class Storage: NSTextStorage {
     ///
     /// - parameter at: The location to begin with.
     /// - parameter range: The range in which to retrieve attributes.
-    public override func attributes(at location: Int, effectiveRange range: NSRangePointer?) -> [NSAttributedStringKey : Any] {
+    public override func attributes(at location: Int, effectiveRange range: NSRangePointer?) -> [NSAttributedString.Key : Any] {
         return backingStore.attributes(at: location, effectiveRange: range)
     }
     


### PR DESCRIPTION
It seems that [this](https://github.com/ruddfawcett/Notepad/commit/9eab1f938fede8c0c75a519ffa3f1e53b126199a) commit unintentionally reverted `NSAttributedString.Key` (Swift 4.2) to `NSAttributedStringKey` (pre-Swift 4.2) on two lines. This PR changes the two lines to use `NSAttributedString.Key`. It also does the same for a third line, but I'm not sure where this third `NSAttributedStringKey` came from.