### PR TITLE
Fix bundle setup to load themes successfully

### DIFF
--- a/Notepad/Theme.swift
+++ b/Notepad/Theme.swift
@@ -30,7 +30,7 @@ public struct Theme {
     ///
     /// - returns: The Theme.
     public init(_ name: String) {
-        let bundle = Bundle(for: object_getClass(self)!)
+        let bundle = Bundle(for: Notepad.self)
         
         let path: String
         


### PR DESCRIPTION
When running the example project I discovered and issue with theme loading. I always received `unable to load themes` error.

This is a fix for the issue. It does initialise the bundle correctly and therefore themes can be loaded again.