### PR TITLE
Refactor font attributes parsing & Allow defining font traits as attribute in theme file

### DIFF
--- a/Notepad/Extensions.swift
+++ b/Notepad/Extensions.swift
@@ -83,3 +83,33 @@ extension String {
         return from ..< to
     }
 }
+
+extension UniversalFont {
+    func with(traits: String, size: CGFloat) -> UniversalFont? {
+        guard let traits = getTraits(from: traits) else {
+            return self
+        }
+        let descriptor = fontDescriptor.withSymbolicTraits(traits) ?? UniversalFontDescriptor(fontAttributes: [:])
+        return UniversalFont(descriptor: descriptor, size: size)
+    }
+    
+    private func getTraits(from traits: String) -> UniversalTraits? {
+        #if os(iOS)
+        switch traits {
+        case "italic": return .traitItalic
+        case "bold": return .traitBold
+        case "expanded": return .traitExpanded
+        case "condensed": return .traitCondensed
+        default: return nil
+        }
+        #elseif os(macOS)
+        switch traits {
+        case "italic": return .italic
+        case "bold": return .bold
+        case "expanded": return .expanded
+        case "condensed": return .condensed
+        default: return nil
+        }
+        #endif
+    }
+}

--- a/Notepad/Extensions.swift
+++ b/Notepad/Extensions.swift
@@ -96,19 +96,19 @@ extension UniversalFont {
     private func getTraits(from traits: String) -> UniversalTraits? {
         #if os(iOS)
         switch traits {
-        case "italic": return .traitItalic
-        case "bold": return .traitBold
-        case "expanded": return .traitExpanded
-        case "condensed": return .traitCondensed
-        default: return nil
+            case "italic": return .traitItalic
+            case "bold": return .traitBold
+            case "expanded": return .traitExpanded
+            case "condensed": return .traitCondensed
+            default: return nil
         }
         #elseif os(macOS)
         switch traits {
-        case "italic": return .italic
-        case "bold": return .bold
-        case "expanded": return .expanded
-        case "condensed": return .condensed
-        default: return nil
+            case "italic": return .italic
+            case "bold": return .bold
+            case "expanded": return .expanded
+            case "condensed": return .condensed
+            default: return nil
         }
         #endif
     }

--- a/Notepad/Theme.swift
+++ b/Notepad/Theme.swift
@@ -129,26 +129,22 @@ public struct Theme {
             stringAttributes[NSAttributedString.Key.foregroundColor] = UniversalColor(hexString: value)
         }
 
-        if let font = attributes["font"] {
-            let fontName = font as! String
-            var fontSize: CGFloat = 15.0
+        if let fontName = attributes["font"] as? String {
+            var fontSize: CGFloat = 15
 
             if let size = attributes["size"] {
                 fontSize = size as! CGFloat
-            }
-            else {
+            } else {
                 let bodyFont: UniversalFont = body.attributes[NSAttributedString.Key.font] as! UniversalFont
                 fontSize = bodyFont.pointSize
             }
 
             if fontName == "System" {
                 stringAttributes[NSAttributedString.Key.font] = UniversalFont.systemFont(ofSize: fontSize)
-            }
-            else {
+            } else {
                 stringAttributes[NSAttributedString.Key.font] = UniversalFont(name: fontName, size: fontSize)
             }
-        }
-        else {
+        } else {
             // Just change font size (based on body font) if no font is specified for item.
             if let size = attributes["size"] {
                 let bodyFont: UniversalFont = body.attributes[NSAttributedString.Key.font] as! UniversalFont

--- a/Notepad/Theme.swift
+++ b/Notepad/Theme.swift
@@ -128,17 +128,11 @@ public struct Theme {
             let value = color as! String
             stringAttributes[NSAttributedString.Key.foregroundColor] = UniversalColor(hexString: value)
         }
+        
+        let bodyFont: UniversalFont = body.attributes[NSAttributedString.Key.font] as! UniversalFont
+        let fontSize: CGFloat = attributes["size"] as? CGFloat ?? bodyFont.pointSize
 
         if let fontName = attributes["font"] as? String {
-            var fontSize: CGFloat = 15
-
-            if let size = attributes["size"] {
-                fontSize = size as! CGFloat
-            } else {
-                let bodyFont: UniversalFont = body.attributes[NSAttributedString.Key.font] as! UniversalFont
-                fontSize = bodyFont.pointSize
-            }
-
             if fontName == "System" {
                 stringAttributes[NSAttributedString.Key.font] = UniversalFont.systemFont(ofSize: fontSize)
             } else {

--- a/Notepad/Theme.swift
+++ b/Notepad/Theme.swift
@@ -122,11 +122,11 @@ public struct Theme {
     ///
     /// - returns: The converted attribute/key constant pairings.
     func parse(_ attributes: [String: AnyObject]) -> [NSAttributedString.Key: Any]? {
-        var final: [NSAttributedString.Key: Any] = [:]
+        var stringAttributes: [NSAttributedString.Key: Any] = [:]
 
         if let color = attributes["color"] {
             let value = color as! String
-            final[NSAttributedString.Key.foregroundColor] = UniversalColor(hexString: value)
+            stringAttributes[NSAttributedString.Key.foregroundColor] = UniversalColor(hexString: value)
         }
 
         if let font = attributes["font"] {
@@ -142,10 +142,10 @@ public struct Theme {
             }
 
             if fontName == "System" {
-                final[NSAttributedString.Key.font] = UniversalFont.systemFont(ofSize: fontSize)
+                stringAttributes[NSAttributedString.Key.font] = UniversalFont.systemFont(ofSize: fontSize)
             }
             else {
-                final[NSAttributedString.Key.font] = UniversalFont(name: fontName, size: fontSize)
+                stringAttributes[NSAttributedString.Key.font] = UniversalFont(name: fontName, size: fontSize)
             }
         }
         else {
@@ -154,11 +154,11 @@ public struct Theme {
                 let bodyFont: UniversalFont = body.attributes[NSAttributedString.Key.font] as! UniversalFont
                 let fontSize = size as! CGFloat
 
-                final[NSAttributedString.Key.font] = UniversalFont(name: bodyFont.fontName, size: fontSize)
+                stringAttributes[NSAttributedString.Key.font] = UniversalFont(name: bodyFont.fontName, size: fontSize)
             }
         }
 
-        return final
+        return stringAttributes
     }
 
     /// Converts a file from JSON to a [String: AnyObject] dictionary.

--- a/Notepad/Theme.swift
+++ b/Notepad/Theme.swift
@@ -80,8 +80,7 @@ public struct Theme {
             }
             else { // Create a default body font so other styles can inherit from it.
                 let attributes = [
-                    NSAttributedString.Key.foregroundColor: UniversalColor.black,
-                    NSAttributedString.Key.font: UniversalFont.systemFont(ofSize: 15)
+                    NSAttributedString.Key.foregroundColor: UniversalColor.black
                 ]
                 body = Style(element: .body, attributes: attributes)
             }

--- a/Notepad/Theme.swift
+++ b/Notepad/Theme.swift
@@ -131,20 +131,21 @@ public struct Theme {
         let bodyFont = body.attributes[NSAttributedString.Key.font] as? UniversalFont
         // if size is set use custom size, otherwise use body font size, otherwise fallback to 15 points
         let fontSize: CGFloat = attributes["size"] as? CGFloat ?? (bodyFont?.pointSize ?? 15)
+        let fontTraits = attributes["traits"] as? String ?? ""
+        var font: UniversalFont?
         
         if let fontName = attributes["font"] as? String, fontName != "System" {
             // use custom font if set
-            stringAttributes[NSAttributedString.Key.font] = UniversalFont(name: fontName, size: fontSize)
-        } else if let font = bodyFont, font.fontName != "System" {
+            font = UniversalFont(name: fontName, size: fontSize)?.with(traits: fontTraits, size: fontSize)
+        } else if let bodyFont = bodyFont, bodyFont.fontName != "System" {
             // use body font if set
-            stringAttributes[NSAttributedString.Key.font] = UniversalFont(name: font.fontName, size: fontSize)
+            font = UniversalFont(name: bodyFont.fontName, size: fontSize)?.with(traits: fontTraits, size: fontSize)
         } else {
             // use system font in all other cases
-            let weight = attributes["weight"] as? String ?? ""
-            let fontWeight = UIFont.Weight(name: weight) // fallback to regular if configured font weight is unknown
-            stringAttributes[NSAttributedString.Key.font] = UniversalFont.systemFont(ofSize: fontSize, weight: fontWeight)
+            font = UniversalFont.systemFont(ofSize: fontSize).with(traits: fontTraits, size: fontSize)
         }
 
+        stringAttributes[NSAttributedString.Key.font] = font
         return stringAttributes
     }
 
@@ -168,24 +169,5 @@ public struct Theme {
         }
 
         return nil
-    }
-}
-
-
-// allow initialization of font weight by string name
-extension UIFont.Weight {
-    init(name: String) {
-        switch name {
-        case "ultraLight": self = UIFont.Weight.ultraLight
-        case "thin": self = UIFont.Weight.thin
-        case "semibold": self = UIFont.Weight.semibold
-        case "regular": self = UIFont.Weight.regular
-        case "medium": self = UIFont.Weight.medium
-        case "light": self = UIFont.Weight.light
-        case "heavy": self = UIFont.Weight.heavy
-        case "bold": self = UIFont.Weight.bold
-        case "black": self = UIFont.Weight.black
-        default: self = UIFont.Weight.regular
-        }
     }
 }

--- a/Notepad/Theme.swift
+++ b/Notepad/Theme.swift
@@ -129,13 +129,17 @@ public struct Theme {
         }
         
         let bodyFont = body.attributes[NSAttributedString.Key.font] as? UniversalFont
+        // if size is set use custom size, otherwise use body font size, otherwise fallback to 15 points
         let fontSize: CGFloat = attributes["size"] as? CGFloat ?? (bodyFont?.pointSize ?? 15)
         
         if let fontName = attributes["font"] as? String, fontName != "System" {
+            // use custom font if set
             stringAttributes[NSAttributedString.Key.font] = UniversalFont(name: fontName, size: fontSize)
         } else if let font = bodyFont, font.fontName != "System" {
+            // use body font if set
             stringAttributes[NSAttributedString.Key.font] = UniversalFont(name: font.fontName, size: fontSize)
         } else {
+            // use system font in all other cases
             stringAttributes[NSAttributedString.Key.font] = UniversalFont.systemFont(ofSize: fontSize)
         }
 

--- a/Notepad/Theme.swift
+++ b/Notepad/Theme.swift
@@ -140,7 +140,9 @@ public struct Theme {
             stringAttributes[NSAttributedString.Key.font] = UniversalFont(name: font.fontName, size: fontSize)
         } else {
             // use system font in all other cases
-            stringAttributes[NSAttributedString.Key.font] = UniversalFont.systemFont(ofSize: fontSize)
+            let weight = attributes["weight"] as? String ?? ""
+            let fontWeight = UIFont.Weight(name: weight) // fallback to regular if configured font weight is unknown
+            stringAttributes[NSAttributedString.Key.font] = UniversalFont.systemFont(ofSize: fontSize, weight: fontWeight)
         }
 
         return stringAttributes
@@ -166,5 +168,24 @@ public struct Theme {
         }
 
         return nil
+    }
+}
+
+
+// allow initialization of font weight by string name
+extension UIFont.Weight {
+    init(name: String) {
+        switch name {
+        case "ultraLight": self = UIFont.Weight.ultraLight
+        case "thin": self = UIFont.Weight.thin
+        case "semibold": self = UIFont.Weight.semibold
+        case "regular": self = UIFont.Weight.regular
+        case "medium": self = UIFont.Weight.medium
+        case "light": self = UIFont.Weight.light
+        case "heavy": self = UIFont.Weight.heavy
+        case "bold": self = UIFont.Weight.bold
+        case "black": self = UIFont.Weight.black
+        default: self = UIFont.Weight.regular
+        }
     }
 }

--- a/Notepad/Theme.swift
+++ b/Notepad/Theme.swift
@@ -124,28 +124,19 @@ public struct Theme {
     func parse(_ attributes: [String: AnyObject]) -> [NSAttributedString.Key: Any]? {
         var stringAttributes: [NSAttributedString.Key: Any] = [:]
 
-        if let color = attributes["color"] {
-            let value = color as! String
-            stringAttributes[NSAttributedString.Key.foregroundColor] = UniversalColor(hexString: value)
+        if let color = attributes["color"] as? String {
+            stringAttributes[NSAttributedString.Key.foregroundColor] = UniversalColor(hexString: color)
         }
         
-        let bodyFont: UniversalFont = body.attributes[NSAttributedString.Key.font] as! UniversalFont
-        let fontSize: CGFloat = attributes["size"] as? CGFloat ?? bodyFont.pointSize
-
-        if let fontName = attributes["font"] as? String {
-            if fontName == "System" {
-                stringAttributes[NSAttributedString.Key.font] = UniversalFont.systemFont(ofSize: fontSize)
-            } else {
-                stringAttributes[NSAttributedString.Key.font] = UniversalFont(name: fontName, size: fontSize)
-            }
+        let bodyFont = body.attributes[NSAttributedString.Key.font] as? UniversalFont
+        let fontSize: CGFloat = attributes["size"] as? CGFloat ?? (bodyFont?.pointSize ?? 15)
+        
+        if let fontName = attributes["font"] as? String, fontName != "System" {
+            stringAttributes[NSAttributedString.Key.font] = UniversalFont(name: fontName, size: fontSize)
+        } else if let font = bodyFont, font.fontName != "System" {
+            stringAttributes[NSAttributedString.Key.font] = UniversalFont(name: font.fontName, size: fontSize)
         } else {
-            // Just change font size (based on body font) if no font is specified for item.
-            if let size = attributes["size"] {
-                let bodyFont: UniversalFont = body.attributes[NSAttributedString.Key.font] as! UniversalFont
-                let fontSize = size as! CGFloat
-
-                stringAttributes[NSAttributedString.Key.font] = UniversalFont(name: bodyFont.fontName, size: fontSize)
-            }
+            stringAttributes[NSAttributedString.Key.font] = UniversalFont.systemFont(ofSize: fontSize)
         }
 
         return stringAttributes

--- a/Notepad/UniversalTypes.swift
+++ b/Notepad/UniversalTypes.swift
@@ -10,8 +10,12 @@
     import UIKit
     public typealias UniversalColor = UIColor
     public typealias UniversalFont = UIFont
+    public typealias UniversalFontDescriptor = UIFontDescriptor
+    public typealias UniversalTraits = UIFontDescriptorSymbolicTraits
 #elseif os(macOS)
     import AppKit
     public typealias UniversalColor = NSColor
     public typealias UniversalFont = NSFont
+    public typealias UniversalFontDescriptor = NSFontDescriptor
+    public typealias UniversalTraits = NSFontDescriptor.SymbolicTraits
 #endif

--- a/Notepad/themes/system-minimal.json
+++ b/Notepad/themes/system-minimal.json
@@ -7,7 +7,7 @@
     },
     "version": "1.0",
     "editor": {
-        "backgroundColor": "#FFFFFF",
+        "backgroundColor": "#FFFFFF"
     },
     "styles": {
         "h1": {

--- a/Notepad/themes/system-minimal.json
+++ b/Notepad/themes/system-minimal.json
@@ -1,0 +1,49 @@
+{
+    "name": "System Minimal",
+    "style": "Light",
+    "author": {
+        "name": "Stefan Trauth",
+        "email": "mail@stefantrauth.de"
+    },
+    "version": "1.0",
+    "editor": {
+        "backgroundColor": "#FFFFFF",
+    },
+    "styles": {
+        "h1": {
+            "color": "#C96667",
+            "size": 20,
+            "traits": "bold"
+        },
+        "h2": {
+            "color": "#C96667"
+        },
+        "h3": {
+            "color": "#C96667"
+        },
+        "body": {
+            "size": 17
+        },
+        "bold": {
+            "traits": "bold",
+            "color": "#D19A66"
+        },
+        "italic": {
+            "traits": "italic",
+            "color": "#C678DD"
+        },
+        "code": {
+            "color": "#95C077"
+        },
+        "handle": {
+            "regex": "[@＠][a-zA-Z0-9_]{1,20}",
+            "color": "#78ddd5"
+        },
+        "url": {
+            "color": "#78aedd"
+        },
+        "image": {
+            "color": "#78aedd"
+        }
+    }
+}


### PR DESCRIPTION
This PR cleans up font attributes parsing and therefore provides a better fallback mechanism to the system font.

I also added the ability to define font traits like `italic`, `bold`, `expanded` and `condensed` as font attributes.

To showcase the new default system font with traits capabilities I added a new theme called `system-minimal.json`.

I ensured it works on iOS and macOS.