### PR TITLE
Add basic dark mode support

### DIFF
--- a/Example/Base.lproj/Main.storyboard
+++ b/Example/Base.lproj/Main.storyboard
@@ -1,25 +1,28 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6211" systemVersion="14A298i" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="BYZ-38-t0r">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14810.12" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <device id="retina5_9" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6204"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14766.15"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--View Controller-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="ViewController" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="Example" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="y3c-jy-aDJ"/>
                         <viewControllerLayoutGuide type="bottom" id="wfy-db-euE"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
                     </view>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
+            <point key="canvasLocation" x="92" y="31"/>
         </scene>
     </scenes>
 </document>

--- a/Notepad/Theme.swift
+++ b/Notepad/Theme.swift
@@ -16,7 +16,7 @@ public struct Theme {
     /// The body style for the Notepad editor.
     public fileprivate(set) var body: Style = Style()
     /// The background color of the Notepad.
-    public fileprivate(set) var backgroundColor: UniversalColor = UniversalColor.white
+    public fileprivate(set) var backgroundColor: UniversalColor = UniversalColor.clear
     /// The tint color (AKA cursor color) of the Notepad.
     public fileprivate(set) var tintColor: UniversalColor = UniversalColor.blue
 

--- a/Notepad/Theme.swift
+++ b/Notepad/Theme.swift
@@ -74,14 +74,21 @@ public struct Theme {
 
         if var allStyles = data["styles"] as? [String: AnyObject] {
             if let bodyStyles = allStyles["body"] as? [String: AnyObject] {
-                if let parsedBodyStyles = parse(bodyStyles) {
+                if var parsedBodyStyles = parse(bodyStyles) {
+                    if #available(iOS 13.0, *) {
+                        if parsedBodyStyles[NSAttributedString.Key.foregroundColor] == nil {
+                            parsedBodyStyles[NSAttributedString.Key.foregroundColor] = UniversalColor.label
+                        }
+                    }
                     body = Style(element: .body, attributes: parsedBodyStyles)
                 }
             }
             else { // Create a default body font so other styles can inherit from it.
-                let attributes = [
-                    NSAttributedString.Key.foregroundColor: UniversalColor.black
-                ]
+                var textColor = UniversalColor.black
+                if #available(iOS 13.0, *) {
+                    textColor = UniversalColor.label
+                }
+                let attributes = [NSAttributedString.Key.foregroundColor: textColor]
                 body = Style(element: .body, attributes: attributes)
             }
 

--- a/Notepad/themes/system-minimal.json
+++ b/Notepad/themes/system-minimal.json
@@ -6,9 +6,6 @@
         "email": "mail@stefantrauth.de"
     },
     "version": "1.0",
-    "editor": {
-        "backgroundColor": "#FFFFFF"
-    },
     "styles": {
         "h1": {
             "color": "#C96667",


### PR DESCRIPTION
This adds basic iOS 13 dark mode support for the minimal theme.

* Use UIColor.label semantic color for body text color when no color is set in theme
* Change background color to clear color if not explicitly set

In a future update this could be extended to maybe provide two different themes and assign each to dark or light appearance.