### PR TITLE
Cocoapods themes path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,4 @@ fastlane/report.xml
 fastlane/Preview.html
 fastlane/screenshots
 fastlane/test_output
+.DS_Store

--- a/Notepad/Theme.swift
+++ b/Notepad/Theme.swift
@@ -64,7 +64,7 @@ public struct Theme {
 
             path = path3
         }
-        else if let path4 = bundle.path(forResource: "\(name)", ofType: "json") {
+        else if let path4 = bundle.path(forResource: name, ofType: "json") {
             
             path = path4
         }

--- a/Notepad/Theme.swift
+++ b/Notepad/Theme.swift
@@ -71,7 +71,7 @@ public struct Theme {
         else {
             
             print("[Notepad] Unable to load your theme file.")
-            
+            assertionFailure()
             return
         }
         

--- a/Notepad/Theme.swift
+++ b/Notepad/Theme.swift
@@ -64,6 +64,10 @@ public struct Theme {
 
             path = path3
         }
+        else if let path4 = bundle.path(forResource: "\(name)", ofType: "json") {
+            
+            path = path4
+        }
         else {
             
             print("[Notepad] Unable to load your theme file.")


### PR DESCRIPTION
Fix theme loading for Cocoapods installations that have yet another path format.

Also `public init(_ name: String)` maybe better changed to an optional `init?(...)` as it is not guaranteed that any `name` will result in a `Theme`.