### PR TITLE
Programatic themes

### DIFF
--- a/Notepad/Style.swift
+++ b/Notepad/Style.swift
@@ -10,19 +10,19 @@ import Foundation
 
 public struct Style {
     var regex: NSRegularExpression!
-    var attributes: [NSAttributedString.Key: Any] = [:]
+    public var attributes: [NSAttributedString.Key: Any] = [:]
 
-    init(element: Element, attributes: [NSAttributedString.Key: Any]) {
+    public init(element: Element, attributes: [NSAttributedString.Key: Any]) {
         self.regex = element.toRegex()
         self.attributes = attributes
     }
 
-    init(regex: NSRegularExpression, attributes: [NSAttributedString.Key: Any]) {
+    public init(regex: NSRegularExpression, attributes: [NSAttributedString.Key: Any]) {
         self.regex = regex
         self.attributes = attributes
     }
 
-    init() {
+    public init() {
         self.regex = Element.unknown.toRegex()
     }
 }

--- a/Notepad/Theme.swift
+++ b/Notepad/Theme.swift
@@ -32,14 +32,14 @@ public struct Theme {
     }
 
     /// The body style for the Notepad editor.
-    public fileprivate(set) var body: Style = Style()
+    public var body: Style = Style()
     /// The background color of the Notepad.
-    public fileprivate(set) var backgroundColor: UniversalColor = UniversalColor.clear
+    public var backgroundColor: UniversalColor = UniversalColor.clear
     /// The tint color (AKA cursor color) of the Notepad.
-    public fileprivate(set) var tintColor: UniversalColor = UniversalColor.blue
+    public var tintColor: UniversalColor = UniversalColor.blue
 
     /// All of the other styles for the Notepad editor.
-    var styles: [Style] = []
+    public var styles: [Style] = []
     
 
     /// Build a theme from a JSON theme file.

--- a/Notepad/Theme.swift
+++ b/Notepad/Theme.swift
@@ -81,6 +81,9 @@ public struct Theme {
             configure(data)
         }
     }
+    
+    public init() {
+    }
 
     /// Configures all of the styles for the Theme.
     ///


### PR DESCRIPTION
With this changes it is now possible both to create `Theme` objects fully programmatically, or also adjust themes read from json files.

Sample fully programatic theme that handles iOS 13 dark mode:

    var theme = Theme()
    theme.body.attributes = [.font :  UIFont.inter(), .foregroundColor : UIColor.secondaryLabel]
    theme.styles.append(Style(element: .h1, attributes: [.font : UIFont.inter(size: 24), .foregroundColor : UIColor.label]))
    theme.styles.append(Style(element: .h2, attributes: [.font : UIFont.inter(size: 18), .foregroundColor : UIColor.label]))
    theme.styles.append(Style(element: .h3, attributes: [.font : UIFont.inter(size: 16), .foregroundColor : UIColor.label]))
    theme.styles.append(Style(element: .bold, attributes: [.font : UIFont.inter(weight: .bold)]))
    theme.styles.append(Style(element: .italic, attributes: [.font : UIFont.inter(italic: true)]))
    theme.styles.append(Style(element: .boldItalic, attributes: [.font : UIFont.inter(weight: .bold, italic: true)]))
    theme.styles.append(Style(element: .code, attributes: [.font : UIFont(name: "CourierNewPSMT", size: 15)!, .foregroundColor : UIColor.label, .backgroundColor : UIColor.secondarySystemBackground]))
    theme.styles.append(Style(element: .image, attributes: [.foregroundColor : UIColor.appTint]))
    theme.styles.append(Style(element: .url, attributes: [.foregroundColor : UIColor.appTint]))

